### PR TITLE
feat(node)!: run action on node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
   path:
     description: 'Path to where maven environment has been installed (sam as $MAVEN_HOME)'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
BREAKING CHANGE: Requires runner capable of running node20 (for self hosted that means runner v2.308.0 or newer). See [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).